### PR TITLE
Fixing more relative import statements

### DIFF
--- a/gerber/__main__.py
+++ b/gerber/__main__.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
     ctx = GerberSvgContext()
     ctx.alpha = 0.95
     for filename in sys.argv[1:]:
-        print "parsing %s" % filename
+        print("parsing %s" % filename)
         if 'GTO' in filename or 'GBO' in filename:
             ctx.color = (1, 1, 1)
             ctx.alpha = 0.8

--- a/gerber/__main__.py
+++ b/gerber/__main__.py
@@ -16,9 +16,9 @@
 # the License.
 
 if __name__ == '__main__':
-    from .common import read
-    from .render import GerberSvgContext
     import sys
+    from gerber.common import read
+    from gerber.render import GerberSvgContext
 
     if len(sys.argv) < 2:
         print >> sys.stderr, "Usage: python -m gerber <filename> <filename>..."

--- a/gerber/__main__.py
+++ b/gerber/__main__.py
@@ -16,9 +16,9 @@
 # the License.
 
 if __name__ == '__main__':
-    import sys
     from gerber.common import read
     from gerber.render import GerberSvgContext
+    import sys
 
     if len(sys.argv) < 2:
         print >> sys.stderr, "Usage: python -m gerber <filename> <filename>..."

--- a/gerber/common.py
+++ b/gerber/common.py
@@ -30,9 +30,9 @@ def read(filename):
         CncFile object representing the file, either GerberFile or
         ExcellonFile. Returns None if file is not an Excellon or Gerber file.
     """
-    import rs274x
-    import excellon
-    from utils import detect_file_format
+    from . import rs274x
+    from . import excellon
+    from .utils import detect_file_format
     fmt = detect_file_format(filename)
     if fmt == 'rs274x':
         return rs274x.read(filename)

--- a/gerber/render/__init__.py
+++ b/gerber/render/__init__.py
@@ -24,5 +24,5 @@ SVG is the only supported format.
 """
 
 
-from svgwrite_backend import GerberSvgContext
-from cairo_backend import GerberCairoContext
+from .svgwrite_backend import GerberSvgContext
+from .cairo_backend import GerberCairoContext

--- a/gerber/tests/test_cam.py
+++ b/gerber/tests/test_cam.py
@@ -4,7 +4,7 @@
 # Author: Hamilton Kibbe <ham@hamiltonkib.be>
 
 from ..cam import CamFile, FileSettings
-from tests import *
+from .tests import *
 
 
 def test_filesettings_defaults():

--- a/gerber/tests/test_common.py
+++ b/gerber/tests/test_common.py
@@ -5,7 +5,7 @@
 from ..common import read
 from ..excellon import ExcellonFile
 from ..rs274x import GerberFile
-from tests import *
+from .tests import *
 
 import os
 

--- a/gerber/tests/test_primitives.py
+++ b/gerber/tests/test_primitives.py
@@ -3,7 +3,7 @@
 
 # Author: Hamilton Kibbe <ham@hamiltonkib.be>
 from ..primitives import *
-from tests import *
+from .tests import *
 
 
 def test_primitive_implementation_warning():

--- a/gerber/tests/test_rs274x.py
+++ b/gerber/tests/test_rs274x.py
@@ -5,7 +5,7 @@
 import os
 
 from ..rs274x import read, GerberFile
-from tests import *
+from .tests import *
 
 
 TOP_COPPER_FILE = os.path.join(os.path.dirname(__file__),

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ METADATA = {
     'license': "Apache",
     'keywords': "gerber tools",
     'url': "http://github.com/curtacircuitos/gerber-tools",
-    'packages': ['gerber'],
+    'packages': ['gerber', 'gerber.render'],
     'long_description': read('README.md'),
     'classifiers':[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
I found them when working on making the package Py3 compatible.
Those relative import statements seem to work fine on Py2.7 too.