### PR TITLE
Add python3 builds to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
   - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
 
 # command to install dependencies
 install: 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
 ## The following requirements were added by pip --freeze:
-Jinja2==2.7.3
+#Jinja2==2.7.3
 MarkupSafe==0.23
-Pygments==1.6
-Sphinx==1.2.3
+#Pygments==1.6
+#Sphinx==1.2.3
 cairocffi==0.6
 cffi==0.8.6
 coverage==3.7.1
-docutils==0.12
+#docutils==0.12
 nose==1.3.4
 numpydoc==0.5
 pycparser==2.10
 pyparsing==2.0.2
 svgwrite==1.1.6
-wsgiref==0.1.2
+#wsgiref==0.1.2


### PR DESCRIPTION
Do we want to run CI tests against python 3 as well now?
I don't use python3, but its easy enough to setup another virtualenv and run the tests on both versions.