### PR TITLE
Updating gerber/__main__.py for Python3

### DIFF
--- a/gerber/__main__.py
+++ b/gerber/__main__.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     import sys
 
     if len(sys.argv) < 2:
-        print >> sys.stderr, "Usage: python -m gerber <filename> <filename>..."
+        sys.stderr.write("Usage: python -m gerber <filename> <filename>...\n")
         sys.exit(1)
 
     ctx = GerberSvgContext()


### PR DESCRIPTION
The statement `print >> sys.stderr` was not Python3 compatible.