### PR TITLE
Make sure apertures get a unit

### DIFF
--- a/gerber/rs274x.py
+++ b/gerber/rs274x.py
@@ -448,6 +448,7 @@ class GerberParser(object):
         else:
             aperture = self.macros[shape].build(modifiers)
 
+        aperture.units = self.settings.units
         self.apertures[d] = aperture
 
     def _evaluate_mode(self, stmt):


### PR DESCRIPTION
I just hit a little issue that apertures aren't assigned a unit, so calling to_metric doesn't do anything. I hope this fixes it without breaking anything!