### PR TITLE
cairo_backend.py: use BytesIO instead of StringIO

### DIFF
--- a/gerber/render/cairo_backend.py
+++ b/gerber/render/cairo_backend.py
@@ -25,10 +25,7 @@ from .render import GerberContext, RenderSettings
 from .theme import THEMES
 from ..primitives import *
 
-try:
-    from cStringIO import StringIO
-except(ImportError):
-    from io import StringIO
+from io import BytesIO
 
 
 class GerberCairoContext(GerberContext):
@@ -125,9 +122,9 @@ class GerberCairoContext(GerberContext):
             self.surface.write_to_png(filename)
 
     def dump_str(self):
-        """ Return a string containing the rendered image.
+        """ Return a byte-string containing the rendered image.
         """
-        fobj = StringIO()
+        fobj = BytesIO()
         self.surface.write_to_png(fobj)
         return fobj.getvalue()
 


### PR DESCRIPTION
This fixes a crash in cairocffi on Python3, and should be compatible
with both python2 and python3. In python2, byte strings are just
strings. In python3, when getting binary data, the user probably wants
a byte string instead of a regular string.