### PR TITLE
Add GerberParser fix for Python 3.x

### DIFF
--- a/gerber/rs274x.py
+++ b/gerber/rs274x.py
@@ -740,7 +740,7 @@ class GerberParser(object):
             # from start and end). We select the center with the least error in
             # radius from all the options with a valid sweep angle.
 
-            sqdist_diff_min = sys.maxint
+            sqdist_diff_min = sys.maxsize
             center = None
             for factors in [(1, 1), (1, -1), (-1, 1), (-1, -1)]:
 


### PR DESCRIPTION
In Python 3, sys.maxint was removed, however its current use
can be safely substituted with sys.maxsize (also in Python 2)

See also: https://docs.python.org/3.1/whatsnew/3.0.html#integers