### PR TITLE
Fix Cairo backend for svg saving and Python 3

### DIFF
--- a/gerber/render/cairo_backend.py
+++ b/gerber/render/cairo_backend.py
@@ -139,7 +139,7 @@ class GerberCairoContext(GerberContext):
         if is_svg:
             self.surface.finish()
             self.surface_buffer.flush()
-            with open(filename, "w") as f:
+            with open(filename, "wb") as f:
                 self.surface_buffer.seek(0)
                 f.write(self.surface_buffer.read())
                 f.flush()


### PR DESCRIPTION
Python 3 fix for Cairo backend and SVG dumping.
Dumping of svg files is never tested. Added a basic test for this use case.