### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Usage Example:
 
 Rendering Examples:
 -------------------
-###Top Composite rendering
+### Top Composite rendering
 ![Composite Top Image](examples/cairo_example.png)
 ![Composite Bottom Image](examples/cairo_bottom.png)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
