### PR TITLE
Added bounds argument to render_layer()

### DIFF
--- a/gerber/render/cairo_backend.py
+++ b/gerber/render/cairo_backend.py
@@ -77,7 +77,7 @@ class GerberCairoContext(GerberContext):
             self.output_ctx = cairo.Context(self.surface)
 
     def render_layer(self, layer, filename=None, settings=None, bgsettings=None,
-                     verbose=False):
+                     verbose=False, bounds=None):
         if settings is None:
             settings = THEMES['default'].get(layer.layer_class, RenderSettings())
         if bgsettings is None:
@@ -87,7 +87,10 @@ class GerberCairoContext(GerberContext):
             if verbose:
                 print('[Render]: Rendering Background.')
             self.clear()
-            self.set_bounds(layer.bounds)
+            if bounds is not None:
+                self.set_bounds(bounds)
+            else:
+                self.set_bounds(layer.bounds)
             self._paint_background(bgsettings)
         if verbose:
             print('[Render]: Rendering {} Layer.'.format(layer.layer_class))


### PR DESCRIPTION
I added a bounds argument to render_layer. The reason is that I want to render a single bitmap for every layer and process them together. The autoscaling of each layer was preventing the multiple bitmaps from lining up. I plan to use board bounds and layer bounds based on the board outline found in the board's IDF3 file.