### PR TITLE
Remove dependency on scipy by adding quickhull implementation to utils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 
 # command to install dependencies
 install:
-  - "pip install --only-binary=scipy -r requirements.txt"
+  - "pip install -r requirements.txt"
   - "pip install -r test-requirements.txt"
   - "pip install coveralls"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 ## The following requirements were added by pip --freeze:
 cairocffi==0.6
-scipy

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ METADATA = {
 }
 
 SETUPTOOLS_METADATA = {
-    'install_requires': ['cairocffi==0.6', 'scipy'],
+    'install_requires': ['cairocffi==0.6'],
 }
 
 


### PR DESCRIPTION
I added a python implementation of quickhull to provide the convex hull functionality that is the only reason we pull in scipy. This allows us to not be dependent on scipy, which is very large and has many dependencies of its own.