### PR TITLE
Add hole support to ADParamStmt.rect and fix cairocffi compatibility

### DIFF
--- a/gerber/gerber_statements.py
+++ b/gerber/gerber_statements.py
@@ -274,14 +274,18 @@ class ADParamStmt(ParamStmt):
     """
 
     @classmethod
-    def rect(cls, dcode, width, height):
+    def rect(cls, dcode, width, height, hole_diameter=None, hole_width=None, hole_height=None):
         '''Create a rectangular aperture definition statement'''
+        if hole_diameter is not None and hole_diameter > 0:
+            return cls('AD', dcode, 'R', ([width, height, hole_diameter],))
+        elif (hole_width is not None and hole_width > 0
+              and hole_height is not None and hole_height > 0):
+            return cls('AD', dcode, 'R', ([width, height, hole_width, hole_height],))
         return cls('AD', dcode, 'R', ([width, height],))
 
     @classmethod
     def circle(cls, dcode, diameter, hole_diameter=None, hole_width=None, hole_height=None):
         '''Create a circular aperture definition statement'''
-
         if hole_diameter is not None and hole_diameter > 0:
             return cls('AD', dcode, 'C', ([diameter, hole_diameter],))
         elif (hole_width is not None and hole_width > 0

--- a/gerber/render/cairo_backend.py
+++ b/gerber/render/cairo_backend.py
@@ -308,20 +308,12 @@ class GerberCairoContext(GerberContext):
         with self._clip_primitive(circle):
             with self._new_mask() as mask:
                 mask.ctx.set_line_width(0)
-                mask.ctx.arc(center[0],
-                             center[1],
-                             radius=(circle.radius * self.scale[0]),
-                             angle1=0,
-                             angle2=(2 * math.pi))
+                mask.ctx.arc(center[0], center[1], (circle.radius * self.scale[0]), 0, (2 * math.pi))
                 mask.ctx.fill()
 
                 if hasattr(circle, 'hole_diameter') and circle.hole_diameter is not None and circle.hole_diameter > 0:
                     mask.ctx.set_operator(cairo.OPERATOR_CLEAR)
-                    mask.ctx.arc(center[0],
-                                 center[1],
-                                 radius=circle.hole_radius * self.scale[0],
-                                 angle1=0,
-                                 angle2=2 * math.pi)
+                    mask.ctx.arc(center[0], center[1], circle.hole_radius * self.scale[0], 0, 2 * math.pi)
                     mask.ctx.fill()
 
                 if (hasattr(circle, 'hole_width') and hasattr(circle, 'hole_height')
@@ -371,9 +363,7 @@ class GerberCairoContext(GerberContext):
                                              and (not self.invert)
                                           else cairo.OPERATOR_OVER)
 
-                    mask.ctx.arc(center[0], center[1],
-                                 radius=rectangle.hole_radius * self.scale[0], angle1=0,
-                                 angle2=2 * math.pi)
+                    mask.ctx.arc(center[0], center[1], rectangle.hole_radius * self.scale[0], 0, 2 * math.pi)
                     mask.ctx.fill()
 
                 if rectangle.hole_width > 0 and rectangle.hole_height > 0:
@@ -405,11 +395,7 @@ class GerberCairoContext(GerberContext):
                 # Render circles
                 for circle in (obround.subshapes['circle1'], obround.subshapes['circle2']):
                     center = self.scale_point(circle.position)
-                    mask.ctx.arc(center[0],
-                                 center[1],
-                                 radius=(circle.radius * self.scale[0]),
-                                 angle1=0,
-                                 angle2=(2 * math.pi))
+                    mask.ctx.arc(center[0], center[1], (circle.radius * self.scale[0]), 0, (2 * math.pi))
                     mask.ctx.fill()
 
                 # Render Rectangle
@@ -425,9 +411,7 @@ class GerberCairoContext(GerberContext):
                 if obround.hole_diameter > 0:
                     # Render the center clear
                     mask.ctx.set_operator(cairo.OPERATOR_CLEAR)
-                    mask.ctx.arc(center[0], center[1],
-                                 radius=obround.hole_radius * self.scale[0], angle1=0,
-                                 angle2=2 * math.pi)
+                    mask.ctx.arc(center[0], center[1], obround.hole_radius * self.scale[0], 0, 2 * math.pi)
                     mask.ctx.fill()
 
                 if obround.hole_width > 0 and obround.hole_height > 0:


### PR DESCRIPTION
I just stumbled upon these while trying out pcb-tools.