### PR TITLE
Skip subdirectories during import

### DIFF
--- a/gerber/pcb.py
+++ b/gerber/pcb.py
@@ -48,6 +48,9 @@ class PCB(object):
             except ParseError:
                 if verbose:
                     print('[PCB]: Skipping file {}'.format(filename))
+            except IOError:
+                if verbose:
+                    print('[PCB]: Skipping file {}'.format(filename))
 
         # Try to guess board name
         if board_name is None:


### PR DESCRIPTION
If you try to import a directory that contains subdirectories it fails and throws an exception.