### PR TITLE
Match full filename instead of the base name

### DIFF
--- a/gerber/layers.py
+++ b/gerber/layers.py
@@ -103,11 +103,11 @@ def load_layer_data(data, filename=None):
 
 def guess_layer_class(filename):
     try:
-        directory, name = os.path.split(filename)
-        name, ext = os.path.splitext(name.lower())
+        directory, filename = os.path.split(filename)
+        name, ext = os.path.splitext(filename.lower())
         for hint in hints:
             if hint.regex:
-                if re.findall(hint.regex, name, re.IGNORECASE):
+                if re.findall(hint.regex, filename, re.IGNORECASE):
                     return hint.layer
 
             patterns = [r'^(\w*[.-])*{}([.-]\w*)?$'.format(x) for x in hint.name]

--- a/gerber/tests/test_layers.py
+++ b/gerber/tests/test_layers.py
@@ -61,7 +61,7 @@ def test_guess_layer_class_regex():
         Hint(layer='top',
                 ext=[],
                 name=[],
-                regex=r'(.*)(\scopper top|\stop copper)$'
+                regex=r'(.*)(\scopper top\.gbr|\stop copper\.gbr)'
             ),
     ]
     hints.extend(layer_hints)


### PR DESCRIPTION
Regular expressions only matched the base name. This matches the entire filename which allows for more advanced regular expressions.