### PR TITLE
Fix cairo matrix clone op to not use copy.copy

### DIFF
--- a/gerber/render/cairo_backend.py
+++ b/gerber/render/cairo_backend.py
@@ -532,7 +532,7 @@ class GerberCairoContext(GerberContext):
 
     def _new_render_layer(self, color=None, mirror=False):
         size_in_pixels = self.scale_point(self.size_in_inch)
-        matrix = copy.copy(self._xform_matrix)
+        matrix = cairo.Matrix() * self._xform_matrix
         layer = cairo.SVGSurface(None, size_in_pixels[0], size_in_pixels[1])
         ctx = cairo.Context(layer)
 


### PR DESCRIPTION
For some reason, copy.copy would barf saying it can't deep copy cairo
matrices. I'm using python 3.6.5 and cairocffi 0.7.2 on Fedora 28.

This PR just replaces the deep copy call with a multiplication by a unity matrix, having the same effect.