### PR TITLE
Fix clear level polarity region rendering

### DIFF
--- a/gerber/gerber_statements.py
+++ b/gerber/gerber_statements.py
@@ -236,11 +236,6 @@ class LPParamStmt(ParamStmt):
         lp = 'clear' if stmt_dict.get('lp') == 'C' else 'dark'
         return cls(param, lp)
 
-    @classmethod
-    def from_region(cls, region):
-        #todo what is the first param?
-        return cls(None, region.level_polarity)
-
     def __init__(self, param, lp):
         """ Initialize LPParamStmt class
 

--- a/gerber/primitives.py
+++ b/gerber/primitives.py
@@ -206,8 +206,9 @@ class Line(Primitive):
     """
     """
 
-    def __init__(self, start, end, aperture, **kwargs):
+    def __init__(self, start, end, aperture, level_polarity=None, **kwargs):
         super(Line, self).__init__(**kwargs)
+        self.level_polarity = level_polarity
         self._start = start
         self._end = end
         self.aperture = aperture
@@ -324,8 +325,9 @@ class Arc(Primitive):
     """
 
     def __init__(self, start, end, center, direction, aperture, quadrant_mode,
-                 **kwargs):
+            level_polarity=None, **kwargs):
         super(Arc, self).__init__(**kwargs)
+        self.level_polarity = level_polarity
         self._start = start
         self._end = end
         self._center = center

--- a/gerber/render/rs274x_backend.py
+++ b/gerber/render/rs274x_backend.py
@@ -178,11 +178,11 @@ class Rs274xContext(GerberContext):
         if hasattr(primitive, 'comment'):
             self.body.append(CommentStmt(primitive.comment))
 
-    def _render_line(self, line, color):
+    def _render_line(self, line, color, default_polarity='dark'):
 
         self._select_aperture(line.aperture)
 
-        self._render_level_polarity(line)
+        self._render_level_polarity(line, default_polarity)
 
         # Get the right function
         if self._func != CoordStmt.FUNC_LINEAR:
@@ -206,7 +206,7 @@ class Rs274xContext(GerberContext):
         elif func:
             self.body.append(CoordStmt.mode(func))
 
-    def _render_arc(self, arc, color):
+    def _render_arc(self, arc, color, default_polarity='dark'):
 
         # Optionally set the quadrant mode if it has changed:
         if arc.quadrant_mode != self._quadrant_mode:
@@ -221,7 +221,7 @@ class Rs274xContext(GerberContext):
         # Select the right aperture if not already selected
         self._select_aperture(arc.aperture)
 
-        self._render_level_polarity(arc)
+        self._render_level_polarity(arc, default_polarity)
 
         # Find the right movement mode. Always set to be sure it is really right
         dir = arc.direction
@@ -252,20 +252,23 @@ class Rs274xContext(GerberContext):
 
         for p in region.primitives:
 
+            # Make programmatically generated primitives within a region with
+            # unset level polarity inherit the region's level polarity
             if isinstance(p, Line):
-                self._render_line(p, color)
+                self._render_line(p, color, default_polarity=region.level_polarity)
             else:
-                self._render_arc(p, color)
+                self._render_arc(p, color, default_polarity=region.level_polarity)
 
         if self.explicit_region_move_end:
             self.body.append(CoordStmt.move(None, None))
 
         self.body.append(RegionModeStmt.off())
 
-    def _render_level_polarity(self, region):
-        if region.level_polarity != self._level_polarity:
-            self._level_polarity = region.level_polarity
-            self.body.append(LPParamStmt.from_region(region))
+    def _render_level_polarity(self, obj, default='dark'):
+        obj_polarity = obj.level_polarity if obj.level_polarity is not None else default
+        if obj_polarity != self._level_polarity:
+            self._level_polarity = obj_polarity
+            self.body.append(LPParamStmt('LP', obj_polarity))
 
     def _render_flash(self, primitive, aperture):
 


### PR DESCRIPTION
This fixes region rendering such that clear level polarity works, as is
needed for e.g. cutouts in regions. Before, the renderer would set level
polarity twice, both when starting the region and then again once for
each region primitive (line or arc). The problem was that the primitives
in a region with "clear" polarity would have unset polarity, defaulting
to "dark". Thus the renderer would emit something like LPC (clear
polarity) -> G36 (start region) -> LPD (dark polarity) -> {lines...}
instead of LPC -> G36 -> {lines...}.

Note on verification: Somehow, gEDA gerbv would still render the broken
regions the way one would have intended, but other viewers (KiCAD
gerbview, the online EasyEDA one and whatever JLC uses to make their
silkscreens) would not.