### PR TITLE
Correctly recognize gEDA pcb generated gerber filenames

### DIFF
--- a/gerber/layers.py
+++ b/gerber/layers.py
@@ -40,10 +40,12 @@ hints = [
          content=[]
          ),
     Hint(layer='internal',
-         ext=['in', 'gt1', 'gt2', 'gt3', 'gt4', 'gt5', 'gt6', 'g1',
-              'g2', 'g3', 'g4', 'g5', 'g6', ],
-         name=['art', 'internal', 'pgp', 'pwr', 'gp1', 'gp2', 'gp3', 'gp4',
-               'gt5', 'gp6', 'gnd', 'ground', 'In1.Cu', 'In2.Cu', 'In3.Cu', 'In4.Cu'],
+         ext=['in', 'gt1', 'gt2', 'gt3', 'gt4', 'gt5', 'gt6',
+              'g1', 'g2', 'g3', 'g4', 'g5', 'g6', ],
+         name=['art', 'internal', 'pgp', 'pwr', 'gnd', 'ground',
+               'gp1', 'gp2', 'gp3', 'gp4', 'gt5', 'gp6',
+               'In1.Cu', 'In2.Cu', 'In3.Cu', 'In4.Cu',
+               'group3', 'group4', 'group5', 'group6', 'group7', 'group8', ],
          regex='',
          content=[]
          ),
@@ -54,21 +56,22 @@ hints = [
          content=[]
          ),
     Hint(layer='bottomsilk',
-         ext=['gbo', 'ssb', 'pls', 'bs', 'skb', 'bottomsilk',],
-         name=['bsilk', 'ssb', 'botsilk', 'B.SilkS'],
+         ext=['gbo', 'ssb', 'pls', 'bs', 'skb', 'bottomsilk', ],
+         name=['bsilk', 'ssb', 'botsilk', 'bottomsilk', 'B.SilkS'],
          regex='',
          content=[]
          ),
     Hint(layer='topmask',
          ext=['gts', 'stc', 'tmk', 'smt', 'tr', 'topmask', ],
          name=['sm01', 'cmask', 'tmask', 'mask1', 'maskcom', 'topmask',
-               'mst', 'F.Mask',],
+               'mst', 'F.Mask', ],
          regex='',
          content=[]
          ),
     Hint(layer='bottommask',
          ext=['gbs', 'sts', 'bmk', 'smb', 'br', 'bottommask', ],
-         name=['sm', 'bmask', 'mask2', 'masksold', 'botmask', 'msb', 'B.Mask',],
+         name=['sm', 'bmask', 'mask2', 'masksold', 'botmask', 'bottommask',
+               'msb', 'B.Mask', ],
          regex='',
          content=[]
          ),
@@ -80,13 +83,13 @@ hints = [
          ),
     Hint(layer='bottompaste',
          ext=['gbp', 'bm', 'bottompaste', ],
-         name=['sp02', 'botpaste', 'psb', 'B.Paste', ],
+         name=['sp02', 'botpaste', 'bottompaste', 'psb', 'B.Paste', ],
          regex='',
          content=[]
          ),
     Hint(layer='outline',
          ext=['gko', 'outline', ],
-         name=['BDR', 'border', 'out', 'Edge.Cuts', ],
+         name=['BDR', 'border', 'out', 'outline', 'Edge.Cuts', ],
          regex='',
          content=[]
          ),
@@ -98,11 +101,19 @@ hints = [
          ),
     Hint(layer='drawing',
          ext=['fab'],
-         name=['assembly drawing', 'assembly', 'fabrication', 'fab drawing'],
+         name=['assembly drawing', 'assembly', 'fabrication',
+               'fab drawing', 'fab'],
          regex='',
          content=[]
          ),
 ]
+
+
+def layer_signatures(layer_class):
+    for hint in hints:
+        if hint.layer == layer_class:
+            return hint.ext + hint.name
+    return []
 
 
 def load_layer(filename):

--- a/gerber/pcb.py
+++ b/gerber/pcb.py
@@ -18,7 +18,7 @@
 
 import os
 from .exceptions import ParseError
-from .layers import PCBLayer, sort_layers
+from .layers import PCBLayer, sort_layers, layer_signatures
 from .common import read as gerber_read
 from .utils import listdir
 
@@ -41,7 +41,14 @@ class PCB(object):
                 camfile = gerber_read(os.path.join(directory, filename))
                 layer = PCBLayer.from_cam(camfile)
                 layers.append(layer)
-                names.add(os.path.splitext(filename)[0])
+                name = os.path.splitext(filename)[0]
+                if len(os.path.splitext(filename)) > 1:
+                    _name, ext = os.path.splitext(name)
+                    if ext[1:] in layer_signatures(layer.layer_class):
+                        name = _name
+                    if layer.layer_class == 'drill' and 'drill' in ext:
+                        name = _name
+                names.add(name)
                 if verbose:
                     print('[PCB]: Added {} layer <{}>'.format(layer.layer_class,
                                                               filename))


### PR DESCRIPTION
gEDA pcb generated gerbers have filenames which are not correctly recognized. This PR adds the necessary strings to the hints and some additional changes needed to correctly handle the gerber files and guess the PCB name correctly.

For reference, the following are the gerbers generated for a 4 layer PCB named "qmb":

```
$ ls -1
qmb.bottom.gbr
qmb.bottommask.gbr
qmb.bottompaste.gbr
qmb.bottomsilk.gbr
qmb.fab.gbr
qmb.group3.gbr
qmb.group4.gbr
qmb.outline.gbr
qmb.plated-drill.cnc
qmb.top.gbr
qmb.topmask.gbr
qmb.toppaste.gbr
qmb.topsilk.gbr
```

