### PR TITLE
Excellon float output and and fix for function pairwise broken by py 3.7

### DIFF
--- a/gerber/excellon_statements.py
+++ b/gerber/excellon_statements.py
@@ -218,20 +218,20 @@ class ExcellonTool(ExcellonStatement):
         zs = settings.zero_suppression
         stmt = 'T%02d' % self.number
         if self.retract_rate is not None:
-            stmt += 'B%s' % write_gerber_value(self.retract_rate, fmt, zs)
+            stmt += 'B%f' % self.retract_rate, fmt
         if self.feed_rate is not None:
-            stmt += 'F%s' % write_gerber_value(self.feed_rate, fmt, zs)
+            stmt += 'F%f' % self.feed_rate, fmt
         if self.max_hit_count is not None:
-            stmt += 'H%s' % write_gerber_value(self.max_hit_count, fmt, zs)
+            stmt += 'H%f' % self.max_hit_count, fmt
         if self.rpm is not None:
             if self.rpm < 100000.:
-                stmt += 'S%s' % write_gerber_value(self.rpm / 1000., fmt, zs)
+                stmt += 'S%f' % self.rpm / 1000., fmt
             else:
                 stmt += 'S%g' % (self.rpm / 1000.)
         if self.diameter is not None:
             stmt += 'C%s' % decimal_string(self.diameter, fmt[1], True)
         if self.depth_offset is not None:
-            stmt += 'Z%s' % write_gerber_value(self.depth_offset, fmt, zs)
+            stmt += 'Z%f' % self.depth_offset, fmt
         return stmt
 
     def to_inch(self):
@@ -617,9 +617,9 @@ class EndOfProgramStmt(ExcellonStatement):
     def to_excellon(self, settings=None):
         stmt = 'M30'
         if self.x is not None:
-            stmt += 'X%s' % write_gerber_value(self.x)
+            stmt += 'X%f' % self.x
         if self.y is not None:
-            stmt += 'Y%s' % write_gerber_value(self.y)
+            stmt += 'Y%f' % self.y
         return stmt
 
     def to_inch(self):

--- a/gerber/excellon_statements.py
+++ b/gerber/excellon_statements.py
@@ -23,6 +23,7 @@ Excellon Statements
 
 import re
 import uuid
+import itertools
 from .utils import (parse_gerber_value, write_gerber_value, decimal_string,
                     inch, metric)
 
@@ -151,8 +152,7 @@ class ExcellonTool(ExcellonStatement):
         tool : Tool
             An ExcellonTool representing the tool defined in `line`
         """
-        commands = re.split('([BCFHSTZ])', line)[1:]
-        commands = [(command, value) for command, value in pairwise(commands)]
+        commands = pairwise(re.split('([BCFHSTZ])', line)[1:])
         args = {}
         args['id'] = id
         nformat = settings.format
@@ -973,6 +973,5 @@ def pairwise(iterator):
 
     e.g. [1, 2, 3, 4, 5, 6] ==> [(1, 2), (3, 4), (5, 6)]
     """
-    itr = iter(iterator)
-    while True:
-        yield tuple([next(itr) for i in range(2)])
+    a, b = itertools.tee(iterator)
+    yield from zip(itertools.islice(a, 0, None, 2), itertools.islice(b, 1, None, 2))

--- a/gerber/excellon_statements.py
+++ b/gerber/excellon_statements.py
@@ -965,5 +965,7 @@ def pairwise(iterator):
     e.g. [1, 2, 3, 4, 5, 6] ==> [(1, 2), (3, 4), (5, 6)]
     """
     a, b = itertools.tee(iterator)
-    yield from zip(itertools.islice(a, 0, None, 2), itertools.islice(b, 1, None, 2))
+    itr = zip(itertools.islice(a, 0, None, 2), itertools.islice(b, 1, None, 2))
+    for elem in itr:
+        yield elem
 

--- a/gerber/excellon_statements.py
+++ b/gerber/excellon_statements.py
@@ -24,8 +24,7 @@ Excellon Statements
 import re
 import uuid
 import itertools
-from .utils import (parse_gerber_value, write_gerber_value, decimal_string,
-                    inch, metric)
+from .utils import (parse_gerber_value, decimal_string, inch, metric)
 
 
 __all__ = ['ExcellonTool', 'ToolSelectionStmt', 'CoordinateStmt',
@@ -406,11 +405,9 @@ class CoordinateStmt(ExcellonStatement):
         if self.mode == "LINEAR":
             stmt += "G01"
         if self.x is not None:
-            stmt += 'X%s' % write_gerber_value(self.x, settings.format,
-                                               settings.zero_suppression)
+            stmt += 'X%f' % self.x
         if self.y is not None:
-            stmt += 'Y%s' % write_gerber_value(self.y, settings.format,
-                                               settings.zero_suppression)
+            stmt += 'Y%f' % self.y
         return stmt
 
     def to_inch(self):
@@ -472,11 +469,9 @@ class RepeatHoleStmt(ExcellonStatement):
     def to_excellon(self, settings):
         stmt = 'R%d' % self.count
         if self.xdelta is not None and self.xdelta != 0.0:
-            stmt += 'X%s' % write_gerber_value(self.xdelta, settings.format,
-                                               settings.zero_suppression)
+            stmt += 'X%f' % self.xdelta
         if self.ydelta is not None and self.ydelta != 0.0:
-            stmt += 'Y%s' % write_gerber_value(self.ydelta, settings.format,
-                                               settings.zero_suppression)
+            stmt += 'Y%f' % self.ydelta
         return stmt
 
     def to_inch(self):
@@ -902,20 +897,16 @@ class SlotStmt(ExcellonStatement):
         stmt = ''
 
         if self.x_start is not None:
-            stmt += 'X%s' % write_gerber_value(self.x_start, settings.format,
-                                               settings.zero_suppression)
+            stmt += 'X%f' % self.x_start
         if self.y_start is not None:
-            stmt += 'Y%s' % write_gerber_value(self.y_start, settings.format,
-                                               settings.zero_suppression)
+            stmt += 'Y%f' % self.y_start
 
         stmt += 'G85'
 
         if self.x_end is not None:
-            stmt += 'X%s' % write_gerber_value(self.x_end, settings.format,
-                                               settings.zero_suppression)
+            stmt += 'X%f' % self.x_end
         if self.y_end is not None:
-            stmt += 'Y%s' % write_gerber_value(self.y_end, settings.format,
-                                               settings.zero_suppression)
+            stmt += 'Y%f' % self.y_end
 
         return stmt
 
@@ -975,3 +966,4 @@ def pairwise(iterator):
     """
     a, b = itertools.tee(iterator)
     yield from zip(itertools.islice(a, 0, None, 2), itertools.islice(b, 1, None, 2))
+

--- a/gerber/excellon_statements.py
+++ b/gerber/excellon_statements.py
@@ -225,7 +225,7 @@ class ExcellonTool(ExcellonStatement):
             stmt += 'H%f' % self.max_hit_count
         if self.rpm is not None:
             if self.rpm < 100000.:
-                stmt += 'S%f' % self.rpm / 1000.
+                stmt += 'S%f' % (self.rpm / 1000.)
             else:
                 stmt += 'S%g' % (self.rpm / 1000.)
         if self.diameter is not None:

--- a/gerber/excellon_statements.py
+++ b/gerber/excellon_statements.py
@@ -218,20 +218,20 @@ class ExcellonTool(ExcellonStatement):
         zs = settings.zero_suppression
         stmt = 'T%02d' % self.number
         if self.retract_rate is not None:
-            stmt += 'B%f' % self.retract_rate, fmt
+            stmt += 'B%f' % self.retract_rate
         if self.feed_rate is not None:
-            stmt += 'F%f' % self.feed_rate, fmt
+            stmt += 'F%f' % self.feed_rate
         if self.max_hit_count is not None:
-            stmt += 'H%f' % self.max_hit_count, fmt
+            stmt += 'H%f' % self.max_hit_count
         if self.rpm is not None:
             if self.rpm < 100000.:
-                stmt += 'S%f' % self.rpm / 1000., fmt
+                stmt += 'S%f' % self.rpm / 1000.
             else:
                 stmt += 'S%g' % (self.rpm / 1000.)
         if self.diameter is not None:
             stmt += 'C%s' % decimal_string(self.diameter, fmt[1], True)
         if self.depth_offset is not None:
-            stmt += 'Z%f' % self.depth_offset, fmt
+            stmt += 'Z%f' % self.depth_offset
         return stmt
 
     def to_inch(self):


### PR DESCRIPTION
Hello,

This is a set of two patches.

b36c520 fixes the function "pairwise" which was broken by PEP 479.

9eb0231 solves an issue faced when using pcb_tools-extensions where a panel going from <10cm to >10cm would have it's excellon file miss-formed causing holes to be wrongly placed.
The fix changes the uses of "write_gerber_value" with a simple float formating, which is more economical and well supported by the Excellon standard.
(Tested with Ucamco, Altium, KiCad and pcb-tools rendering).

Regards,
Mikaël