### PR TITLE
Allow float fmt and fix 3.7

### DIFF
--- a/gerber/excellon_statements.py
+++ b/gerber/excellon_statements.py
@@ -23,6 +23,7 @@ Excellon Statements
 
 import re
 import uuid
+import itertools
 from .utils import (parse_gerber_value, write_gerber_value, decimal_string,
                     inch, metric)
 
@@ -151,8 +152,7 @@ class ExcellonTool(ExcellonStatement):
         tool : Tool
             An ExcellonTool representing the tool defined in `line`
         """
-        commands = re.split('([BCFHSTZ])', line)[1:]
-        commands = [(command, value) for command, value in pairwise(commands)]
+        commands = pairwise(re.split('([BCFHSTZ])', line)[1:])
         args = {}
         args['id'] = id
         nformat = settings.format
@@ -973,6 +973,7 @@ def pairwise(iterator):
 
     e.g. [1, 2, 3, 4, 5, 6] ==> [(1, 2), (3, 4), (5, 6)]
     """
-    itr = iter(iterator)
-    while True:
-        yield tuple([next(itr) for i in range(2)])
+    a, b = itertools.tee(iterator)
+    itr = zip(itertools.islice(a, 0, None, 2), itertools.islice(b, 1, None, 2))
+    for elem in itr:
+        yield elem

--- a/gerber/utils.py
+++ b/gerber/utils.py
@@ -123,6 +123,10 @@ def write_gerber_value(value, format=(2, 5), zero_suppression='trailing'):
     value : string
         The specified value as a Gerber/Excellon-formatted string.
     """
+    
+    if format[0] == float:
+        return "%f" %value
+    
     # Format precision
     integer_digits, decimal_digits = format
     MAX_DIGITS = integer_digits + decimal_digits


### PR DESCRIPTION
Hello,

This PR replaces PR#103 with a more efficient and retro-compatible implementation.

This PR does two things:

1) pairwise function is now compatible with 3.7 as well as all tested python versions
2) Allow the use of float format in FileSettings:
Use:
fs = FileSettings(units="metric", zeros="trailing", format=(float,3))

This configuration will be used in writer_gerber_value to use a float representation.

Why ? Most tools are now compatible with floats in excellon files, and this allows the use of larger PCB, especially in the case of panelized PCBs using opiopan's library.

I only changed the first element of the format tupple for two reasons:
* It is very compatible with the rest of the code (no modifications other than the intended one)
* Tools configuration still require the 3nd number of the format variable to write their diameters.

Mikaël
