### PR TITLE
Fix typo in license trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ METADATA = {
     'classifiers': [
         "Development Status :: 3 - Alpha",
         "Topic :: Utilities",
-        "License :: OSI Approved :: Apple Public Source License",
+        "License :: OSI Approved :: Apache Software License",
     ],
 }
 


### PR DESCRIPTION
Every other reference to the license for this project states Apache 2.0, so I presume that it was a typo that "Apple Public Source" license was stated in the trove classifier?

- https://github.com/curtacircuitos/pcb-tools/blob/efb46c562cf1cfdf0f340cff81cea8bc06e97dc4/LICENSE#L1-L3
- https://github.com/curtacircuitos/pcb-tools/blob/efb46c562cf1cfdf0f340cff81cea8bc06e97dc4/setup.py#L30