### PR TITLE
Fix math error in clipping code

### DIFF
--- a/gerber/render/cairo_backend.py
+++ b/gerber/render/cairo_backend.py
@@ -594,7 +594,7 @@ class GerberCairoContext(GerberContext):
                 # caused by flipping the axis.
                 clp.ymin = math.floor(
                     (self.scale[1] * ymin) - math.ceil(self.origin_in_pixels[1]))
-                clp.ymax = math.floor(
+                clp.ymax = math.ceil(
                     (self.scale[1] * ymax) - math.floor(self.origin_in_pixels[1]))
 
                 # Calculate width and height, rounded to the nearest pixel


### PR DESCRIPTION
ymax should be the ceil of the argument, not the floor.