### PR TITLE
Include OF (offset) command

### DIFF
--- a/gerber/rs274x.py
+++ b/gerber/rs274x.py
@@ -247,6 +247,8 @@ class GerberParser(object):
         self.current_region = None
         self.x = 0
         self.y = 0
+        self.offset_a = 0 
+        self.offset_b = 0 
         self.op = "D02"
         self.aperture = 0
         self.interpolation = 'linear'
@@ -614,10 +616,15 @@ class GerberParser(object):
             self.macros[stmt.name] = stmt
         elif stmt.param == "AD":
             self._define_aperture(stmt.d, stmt.shape, stmt.modifiers)
+        elif stmt.param == "OF":
+            # offset parameters are persistent until the next offset parameter,
+            # which replaces (rather than adds to) the previous offset parameter
+            self.offset_a = self.offset_a if stmt.a is None else stmt.a  
+            self.offset_b = self.offset_b if stmt.b is None else stmt.b  
 
     def _evaluate_coord(self, stmt):
-        x = self.x if stmt.x is None else stmt.x
-        y = self.y if stmt.y is None else stmt.y
+        x = (self.x if stmt.x is None else stmt.x) + self.offset_a
+        y = (self.y if stmt.y is None else stmt.y) + self.offset_b
 
         if stmt.function in ("G01", "G1"):
             self.interpolation = 'linear'


### PR DESCRIPTION
Add basic way to have the OF (offset) command work in a way that is consistent with the official gerber viewer at [https://gerber-viewer.ucamco.com/](https://gerber-viewer.ucamco.com/)

```
%OF[A<±offset value>][B±offset value>]
```

> It is listed a deprecated command, but I think it would be still be good to support it for older files, but I suppose that is for the project manager to decide

> In the newer spec it states that the command it to be used only once per file, but in older versions (Rev D, 2001) it merely states that a single use is _recommended_. A machine I use that takes gerber files has no issues with multiple %OF%* commands in the same file

You can see the difference in the output of the following example file
```
%FSLAX25Y25*%
%MOMM*%

%ADD13R,0.4X1*%
G04 flash aperture 3 times, using the offset command*

D13*
X0Y0D03*

%OFA5B5*%
X0Y0D03*

%OFA-3B1*%
X0Y0D03*

M02*
```

The output SVG file (using `GerberCairoContext`) looks like the preview of the gerber file that the official viewer would give.

![ucamco_basic_offset](https://user-images.githubusercontent.com/8851596/118376654-a5d22a00-b5c9-11eb-8f08-77a4fbaabc2e.JPG)

![inkscape_basic_offset](https://user-images.githubusercontent.com/8851596/118376657-a965b100-b5c9-11eb-80cb-3d2e0cc3480d.JPG)

Without these changes the three flashes are all drawn at the same location (where each identical `X0Y0D03` statement specifies)

_p.s. I am not familiar with pull requests, so if I am breaking some kind of unwritten rules or if I should format things differently, do not hesitate to let me know._