### PR TITLE
Bugfix for Polygon Aperture Macros

### DIFF
--- a/gerber/am_statements.py
+++ b/gerber/am_statements.py
@@ -547,7 +547,7 @@ class AMPolygonPrimitive(AMPrimitive):
         return fmt.format(**data)
 
     def to_primitive(self, units):
-        return Polygon(self.position, self.vertices, self.diameter / 2.0, 0, rotation=math.radians(self.rotation), units=units, level_polarity=self._level_polarity)
+        return Polygon(self.position, self.vertices, self.diameter / 2.0, 0, rotation=self.rotation, units=units, level_polarity=self._level_polarity)
 
 
 class AMMoirePrimitive(AMPrimitive):


### PR DESCRIPTION
Remove unit conversion since Polygon expects degree. This bug leads to false rotated polygons in aperture macros.