### PR TITLE
Aperture Macro - Correctly read subtraction operations and evaluations

### DIFF
--- a/gerber/am_eval.py
+++ b/gerber/am_eval.py
@@ -92,7 +92,7 @@ def eval_macro(instructions, parameters={}):
         elif opcode == OpCode.SUB:
             op1 = pop()
             op2 = pop()
-            push(op2 - op2)
+            push(op2 - op1)
 
         elif opcode == OpCode.MUL:
             op1 = pop()

--- a/gerber/am_read.py
+++ b/gerber/am_read.py
@@ -200,6 +200,7 @@ def read_macro(macro):
                     equation_left_side = n
                 else:
                     instructions.append((OpCode.LOAD, n))
+                    unary_minus_allowed = False
 
             elif c == Token.EQUALS:
                 found_equation_left_side = True
@@ -212,6 +213,7 @@ def read_macro(macro):
                     # decimal or integer disambiguation
                     if scanner.peek() not in '.' or scanner.peek() == Token.EOF:
                         instructions.append((OpCode.PUSH, 0))
+                        unary_minus_allowed = False
 
             elif c in "123456789.":
                 scanner.ungetc()
@@ -225,6 +227,7 @@ def read_macro(macro):
                         n *= -1
 
                     instructions.append((OpCode.PUSH, n))
+                    unary_minus_allowed = False
             else:
                 # whitespace or unknown char
                 pass


### PR DESCRIPTION
The recent update in EasyEDA software exports aperture macros with non-evaluated subtraction operations.

Example-
```
%AMMACRO1*1,1,$1,$2,$3*1,1,$1,$4,$5*1,1,$1,0-$2,0-$3*1,1,$1,0-$4,0-$5*20,1,$1,$2,$3,$4,$5,0*20,1,$1,$4,$5,0-$2,0-$3,0*20,1,$1,0-$2,0-$3,0-$4,0-$5,0*20,1,$1,0-$4,0-$5,$2,$3,0*4,1,4,$2,$3,$4,$5,0-$2,0-$3,0-$4,0-$5,$2,$3,0*%
%ADD11MACRO1,0.1016X-0.7874X-0.85X-0.7874X0.85*%
```

The AM statement reader assumed the negative operations would be pre-evaluated and the command would contain only unary negative values. In the above example, operation `0-$2` was being read as `0, $2`